### PR TITLE
Fixes float and double serialization for some cultures

### DIFF
--- a/Serialization.NET/Segment/Serialization/JsonElement.cs
+++ b/Serialization.NET/Segment/Serialization/JsonElement.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 #if NETSTANDARD2_0
@@ -61,6 +62,19 @@ namespace Segment.Serialization
 
         public static JsonPrimitive Create(object value, bool isString)
         {
+            if (value is string s)
+            {
+                if (float.TryParse(s, out var f))
+                {
+                    return new JsonLiteral(f, isString);
+                }
+
+                if (double.TryParse(s, out var d))
+                {
+                    return new JsonLiteral(d, isString);
+                }
+            }
+
             return new JsonLiteral(value, isString);
         }
     }
@@ -74,7 +88,19 @@ namespace Segment.Serialization
         internal JsonLiteral(object body, bool isString)
         {
             IsString = isString;
-            Content = body.ToString();
+
+            switch (body)
+            {
+                case float f:
+                    Content = f.ToString(CultureInfo.InvariantCulture);
+                    break;
+                case double d:
+                    Content = d.ToString(CultureInfo.InvariantCulture);
+                    break;
+                default:
+                    Content = body.ToString();
+                    break;
+            }
         }
 
         public override string ToString()

--- a/Tests/DecimalNumberSerializationTest.cs
+++ b/Tests/DecimalNumberSerializationTest.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Segment.Serialization;
+using Xunit;
+
+namespace Tests
+{
+    public class DecimalNumberSerializationTest
+    {
+        private class CurrentCultureScope : IDisposable
+        {
+            private readonly CultureInfo _originalCurrentCulture;
+
+            public CurrentCultureScope(CultureInfo cultureInfo)
+            {
+                _originalCurrentCulture = CultureInfo.CurrentCulture;
+                CultureInfo.CurrentCulture = cultureInfo;
+            }
+
+            public void Dispose()
+            {
+                CultureInfo.CurrentCulture = _originalCurrentCulture;
+            }
+        }
+
+        [Fact]
+        public void TestDecimalNumberSerializationForAllCultures()
+        {
+            var eventParameters = new Dictionary<string, object> { { "FloatNumber", 1.23f } };
+
+            foreach (var cultureInfo in CultureInfo.GetCultures(CultureTypes.AllCultures))
+            {
+                using (new CurrentCultureScope(cultureInfo))
+                {
+                    var eventParametersJson = JsonUtility.ToJson(eventParameters); // This call exist inside Segment.Analytics.Analytics::Track<T>
+                    var jsonObject = JsonUtility.FromJson<JsonObject>(eventParametersJson); // This call exist inside Segment.Analytics.Analytics::Track<T>
+                    var payloadJson = JsonUtility.ToJson(jsonObject); // Later, when dispatching the event to the analytics server, jsonObject gets serialized as JSON. If any float was serialized under pt-BR culture (which uses comma as a decimal separator), the JSON will be malformed and rejected by server.
+                    Assert.True(payloadJson != null);
+                    var payloadHashSet = new HashSet<char>(payloadJson); // Straight character comparison without culture info
+                    Assert.Contains('.', payloadHashSet);
+                    Assert.DoesNotContain(',', payloadHashSet);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
Fixes `float` and `double` serialization for cultures that use `comma` as decimal separator. `pt-BR` for instance uses `comma` instead of `dot` as decimal separator.

Also I added a unit test that checks in every available culture if a serialized number is always serialized with `dot` instead of `comma`. And its passing on every target platform.

### How JSON payload looked like before fix
![image](https://github.com/user-attachments/assets/88db1583-c03f-49b1-94c8-3e456e3962f2)
This results in a payload rejection by server, due to malformed JSON.

### How JSON payload looks like after fix
![image](https://github.com/user-attachments/assets/6460d654-55cb-479b-b72a-6b7a1eff1ef0)

