### PR TITLE
Fixes version serialization

### DIFF
--- a/Serialization.NET/Segment/Serialization/JsonElement.cs
+++ b/Serialization.NET/Segment/Serialization/JsonElement.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
@@ -88,6 +89,11 @@ namespace Segment.Serialization
         {
             if (value is string s)
             {
+                if (Version.TryParse(s, out _) || s.Count(character => character == '.') > 1) // Consider strings with multiple dots as version numbers as System.Version.TryParse() does not handle int64 revision numbers like date times
+                {
+                    return new JsonLiteral(s, isString);
+                }
+
                 if (float.TryParse(s, out var f))
                 {
                     return new JsonLiteral(f, isString);

--- a/Tests/CurrentCultureScope.cs
+++ b/Tests/CurrentCultureScope.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Globalization;
+
+namespace Tests
+{
+    internal class CurrentCultureScope : IDisposable
+    {
+        private readonly CultureInfo _originalCurrentCulture;
+
+        public CurrentCultureScope(CultureInfo cultureInfo)
+        {
+            _originalCurrentCulture = CultureInfo.CurrentCulture;
+            CultureInfo.CurrentCulture = cultureInfo;
+        }
+
+        public void Dispose()
+        {
+            CultureInfo.CurrentCulture = _originalCurrentCulture;
+        }
+    }
+}

--- a/Tests/DecimalNumberSerializationTest.cs
+++ b/Tests/DecimalNumberSerializationTest.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Globalization;
 using Segment.Serialization;
 using Xunit;
@@ -8,22 +7,6 @@ namespace Tests
 {
     public class DecimalNumberSerializationTest
     {
-        private class CurrentCultureScope : IDisposable
-        {
-            private readonly CultureInfo _originalCurrentCulture;
-
-            public CurrentCultureScope(CultureInfo cultureInfo)
-            {
-                _originalCurrentCulture = CultureInfo.CurrentCulture;
-                CultureInfo.CurrentCulture = cultureInfo;
-            }
-
-            public void Dispose()
-            {
-                CultureInfo.CurrentCulture = _originalCurrentCulture;
-            }
-        }
-
         [Fact]
         public void TestDecimalNumberSerializationForAllCultures()
         {

--- a/Tests/VersionSerializationTests.cs
+++ b/Tests/VersionSerializationTests.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using Segment.Serialization;
+using Xunit;
+
+namespace Tests
+{
+    public class VersionSerializationTests
+    {
+        [Fact]
+        public static void TestLongVersionNumberSerializationForAllCultures()
+        {
+            const string longVersion = "1.2.3.02601051535";
+            var eventParameters = new Dictionary<string, object> { { "Version", longVersion } };
+
+            foreach (var cultureInfo in CultureInfo.GetCultures(CultureTypes.AllCultures))
+            {
+                using (new CurrentCultureScope(cultureInfo))
+                {
+                    var json = JsonUtility.ToJson(eventParameters);
+                    var jsonObject = JsonUtility.FromJson<JsonObject>(json);
+                    Assert.Equal(expected: longVersion, actual: jsonObject.GetString("Version"));
+                }
+            }
+        }
+
+        [Fact]
+        public static void TestShortVersionNumberSerializationForAllCultures()
+        {
+            const string shortVersion = "1.2.3.4"; // The same as 'new Version(1, 2, 3, 4).ToString()'
+            var eventParameters = new Dictionary<string, object> { { "Version", shortVersion } };
+
+            foreach (var cultureInfo in CultureInfo.GetCultures(CultureTypes.AllCultures))
+            {
+                using (new CurrentCultureScope(cultureInfo))
+                {
+                    var json = JsonUtility.ToJson(eventParameters);
+                    var jsonObject = JsonUtility.FromJson<JsonObject>(json);
+                    Assert.Equal(expected: shortVersion, actual: jsonObject.GetString("Version"));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description
Version numbers with multiple dots were being missinterpreted by float.TryParse, leading to serialization/deserialization issues.

### Without this code changes, this two tests I've added does not pass:
<img width="789" height="251" alt="Captura de tela 2026-01-06 153713" src="https://github.com/user-attachments/assets/86b1d35f-a329-4afb-ae86-1e5e0cff331f" />
<img width="769" height="240" alt="Captura de tela 2026-01-06 153708" src="https://github.com/user-attachments/assets/5866ba04-8c88-4a9d-9ce8-54b64b0ecd8c" />

### After implementing this change, all tests from solution keeps passing:
<img width="718" height="444" alt="image" src="https://github.com/user-attachments/assets/08618718-b6a3-4784-a522-639122757328" />
