### PR TITLE
Fixes ints and longs being serialized as scientific notation

### DIFF
--- a/Serialization.NET/Segment/Serialization/JsonElement.cs
+++ b/Serialization.NET/Segment/Serialization/JsonElement.cs
@@ -88,11 +88,6 @@ namespace Segment.Serialization
         {
             if (value is string s)
             {
-                if (float.TryParse(s, out var f))
-                {
-                    return new JsonLiteral(f, isString);
-                }
-
                 if (double.TryParse(s, out var d))
                 {
                     return new JsonLiteral(d, isString);

--- a/Serialization.NET/Segment/Serialization/JsonElement.cs
+++ b/Serialization.NET/Segment/Serialization/JsonElement.cs
@@ -88,6 +88,11 @@ namespace Segment.Serialization
         {
             if (value is string s)
             {
+                if (long.TryParse(s, out var l))
+                {
+                    return new JsonLiteral(l, isString);
+                }
+
                 if (double.TryParse(s, out var d))
                 {
                     return new JsonLiteral(d, isString);

--- a/Tests/JsonPrimitiveTests.cs
+++ b/Tests/JsonPrimitiveTests.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using Segment.Serialization;
+using Xunit;
+
+namespace Tests
+{
+    public class JsonPrimitiveTests
+    {
+        [Fact]
+        public void EnsureIntAreNotSerializedWithScientificNotation()
+        {
+            var dict =  new Dictionary<string, object>
+            {
+                {"IntNumber", int.MaxValue.ToString()}
+            };
+
+            var serialized = JsonUtility.ToJson(dict); // This call exist inside Segment.Analytics.Analytics::Track<T>
+            var deserialized = JsonUtility.FromJson<JsonObject>(serialized); // This call exist inside Segment.Analytics.Analytics::Track<T>
+            Assert.Equal(expected: int.MaxValue.ToString(), actual: deserialized.GetString("IntNumber"));
+        }
+
+        [Fact]
+        public void EnsureLongAreNotSerializedWithScientificNotation()
+        {
+            var dict =  new Dictionary<string, object>
+            {
+                {"LongNumber", long.MaxValue.ToString()}
+            };
+
+            var serialized = JsonUtility.ToJson(dict); // This call exist inside Segment.Analytics.Analytics::Track<T>
+            var deserialized = JsonUtility.FromJson<JsonObject>(serialized); // This call exist inside Segment.Analytics.Analytics::Track<T>
+            Assert.Equal(expected: long.MaxValue.ToString(), actual: deserialized.GetString("LongNumber"));
+        }
+    }
+}


### PR DESCRIPTION
## Issue
When sending a string containing a long or a int, Segment.Serialization.NET was transforming it into a scientific notation number which is not expected:
<img width="479" height="120" alt="image" src="https://github.com/user-attachments/assets/236cbf29-0992-40f0-8adf-c28e37adaac7" />

## PR Description
This PR fixes strings containing int or long being serialized as scientific notation and also adds two unit tests `EnsureIntAreNotSerializedWithScientificNotation` and `EnsureLongAreNotSerializedWithScientificNotation` to ensure this issue does not regress.

After the changes, all tests were executed and passed on both `.NET6` and `.NET Framework 4.6`
<img width="708" height="430" alt="image" src="https://github.com/user-attachments/assets/8fed0dca-1ccc-4db0-84a4-1891ba17b14a" />




